### PR TITLE
Add OpenSSF Scorecard schedule

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,0 +1,18 @@
+name: OpenSSF Scorecard
+on:
+    push:
+        branches: [main]
+    schedule:
+        - cron: '30 4 * * 1'
+    workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+    scorecard:
+        uses: platform-mesh/.github/.github/workflows/job-ossf-scorecard.yml@main
+        permissions:
+            security-events: write
+            id-token: write
+            contents: read
+            actions: read

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 # Platform Mesh Portal
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/platform-mesh/portal/badge)](https://scorecard.dev/viewer/?uri=github.com/platform-mesh/portal)
 ![Build Status](https://github.com/platform-mesh/portal/actions/workflows/pipeline.yaml/badge.svg)
 [![REUSE status](
 https://api.reuse.software/badge/github.com/platform-mesh/portal)](https://api.reuse.software/info/github.com/platform-mesh/portal)


### PR DESCRIPTION
Releates to https://github.com/platform-mesh/backlog/issues/227

Enables the OpenSSF Scorecard by calling a schedule workflow every monday at 4:30 AM.

- Seperate Pipeline because the Scorecard should only run by pushes on main and scheduled. 

_Second commit says also add version badge - just added the openssf badge, that was a terminal history accident_