### PR TITLE
feat: add IAS token endpoint and inject it into Luigi global context

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { PortalModule, PortalModuleOptions } from '@openmfp/portal-server-lib';
+import { IasTokenController } from './ias-token.controller.js';
 import {
   AccountEntityContextProvider,
   KcpKubernetesService,
@@ -42,5 +43,6 @@ const portalOptions: PortalModuleOptions = {
 
 @Module({
   imports: [PortalModule.create(portalOptions)],
+  controllers: [IasTokenController],
 })
 export class AppModule {}

--- a/backend/src/ias-token.controller.ts
+++ b/backend/src/ias-token.controller.ts
@@ -1,0 +1,109 @@
+import {
+  Controller,
+  Get,
+  Req,
+  UnauthorizedException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import axios, { AxiosError } from 'axios';
+
+const KEYCLOAK_URL =
+  process.env.KEYCLOAK_INTERNAL_URL ||
+  'http://keycloak.platform-mesh-system.svc.cluster.local:80/keycloak';
+const KEYCLOAK_REALM = process.env.KEYCLOAK_REALM || 'sap';
+const KEYCLOAK_IDP_ALIAS = process.env.KEYCLOAK_IDP_ALIAS || 'sap';
+const KEYCLOAK_CLIENT_ID =
+  process.env.KEYCLOAK_CLIENT_ID || '45e3cde8-cfb1-46f6-bcf2-3d73bce20ba9';
+const KEYCLOAK_CLIENT_SECRET =
+  process.env.KEYCLOAK_CLIENT_SECRET || '03PDSwt5QAHidllH718GOmgQuERPWwSd';
+
+@Controller('api')
+export class IasTokenController {
+  @Get('ias-token')
+  async getIasToken(@Req() req: Request): Promise<{ iasToken: string }> {
+    const refreshToken: string | undefined =
+      req.cookies?.['openmfp_auth_cookie'];
+    if (!refreshToken) {
+      throw new UnauthorizedException('No session cookie found');
+    }
+
+    const keycloakAccessToken = await this.fetchKeycloakAccessToken(refreshToken);
+    const iasToken = await this.fetchIasTokenFromBroker(keycloakAccessToken);
+
+    return { iasToken };
+  }
+
+  private async fetchKeycloakAccessToken(refreshToken: string): Promise<string> {
+    try {
+      const tokenUrl = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`;
+      const credentials = Buffer.from(
+        `${KEYCLOAK_CLIENT_ID}:${KEYCLOAK_CLIENT_SECRET}`,
+      ).toString('base64');
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      });
+      const response = await axios.post<{ access_token?: string }>(
+        tokenUrl,
+        body.toString(),
+        {
+          headers: {
+            Authorization: `Basic ${credentials}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+        },
+      );
+      const accessToken = response.data.access_token;
+      if (!accessToken) {
+        throw new InternalServerErrorException(
+          'No access_token in token response',
+        );
+      }
+      return accessToken;
+    } catch (e: unknown) {
+      if (e instanceof InternalServerErrorException) throw e;
+      const detail = axiosErrorDetail(e);
+      console.error(`[ias-token] token refresh failed: ${detail}`);
+      throw new UnauthorizedException('Failed to refresh Keycloak token');
+    }
+  }
+
+  private async fetchIasTokenFromBroker(
+    keycloakAccessToken: string,
+  ): Promise<string> {
+    try {
+      const brokerUrl = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/broker/${KEYCLOAK_IDP_ALIAS}/token`;
+      const response = await axios.get<{ access_token?: string }>(brokerUrl, {
+        headers: {
+          Authorization: `Bearer ${keycloakAccessToken}`,
+          'X-Forwarded-Proto': 'https',
+          'X-Forwarded-Host': 'portal.localhost:8443',
+        },
+      });
+      const iasToken = response.data.access_token;
+      if (!iasToken) {
+        throw new InternalServerErrorException(
+          'No access_token in broker response',
+        );
+      }
+      return iasToken;
+    } catch (e: unknown) {
+      if (e instanceof InternalServerErrorException) throw e;
+      const detail = axiosErrorDetail(e);
+      console.error(`[ias-token] broker failed: ${detail}`);
+      throw new UnauthorizedException(
+        'Failed to retrieve IAS token from Keycloak broker',
+      );
+    }
+  }
+}
+
+function axiosErrorDetail(e: unknown): string {
+  if (e instanceof AxiosError) {
+    return e.response?.data
+      ? JSON.stringify(e.response.data)
+      : (e.message ?? 'unknown');
+  }
+  return e instanceof Error ? e.message : 'unknown error';
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,10 @@
 import { AppModule } from './app.module.js';
 import { NestFactory } from '@nestjs/core';
+import cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.use(cookieParser());
   await app.listen(process.env.PORT || 3000);
 }
 bootstrap();

--- a/frontend/src/app/services/pm-luigi-extended-global-context.service.ts
+++ b/frontend/src/app/services/pm-luigi-extended-global-context.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { LuigiExtendedGlobalContextConfigService } from '@openmfp/portal-ui-lib';
+import { LuigiExtendedGlobalContextConfigServiceImpl } from '@platform-mesh/portal-ui-lib/portal-options';
+
+@Injectable({ providedIn: 'root' })
+export class PMLuigiExtendedGlobalContextService
+  implements LuigiExtendedGlobalContextConfigService
+{
+  private http = inject(HttpClient);
+  private base = inject(LuigiExtendedGlobalContextConfigServiceImpl);
+
+  async createLuigiExtendedGlobalContext(): Promise<Record<string, any>> {
+    const [baseContext, iasToken] = await Promise.all([
+      this.base.createLuigiExtendedGlobalContext(),
+      this.fetchIasToken(),
+    ]);
+
+    return { ...baseContext, iasToken };
+  }
+
+  private async fetchIasToken(): Promise<string | undefined> {
+    try {
+      const response = await firstValueFrom(
+        this.http.get<{ iasToken: string }>('/api/ias-token'),
+      );
+      return response.iasToken;
+    } catch (e) {
+      console.error('[portal] failed to fetch IAS token', e);
+      return undefined;
+    }
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,12 +9,12 @@ import {
 import {
   CustomRoutingConfigServiceImpl,
   HeaderBarConfigServiceImpl,
-  LuigiExtendedGlobalContextConfigServiceImpl,
   NavigationRedirectStrategyServiceImpl,
   NodeChangeHookConfigServiceImpl,
   NodeContextProcessingServiceImpl,
   UserProfileConfigServiceImpl,
 } from '@platform-mesh/portal-ui-lib/portal-options';
+import { PMLuigiExtendedGlobalContextService } from './app/services/pm-luigi-extended-global-context.service';
 import { routes } from './app/app.routes';
 import { PMStaticSettingsConfigService } from './app/services/pm-static-settings-config.service';
 import { PMCustomGlobalNodesService } from './app/services/pm-custom-global-nodes.service';
@@ -25,7 +25,7 @@ const portalOptions: PortalOptions = {
   customGlobalNodesService: PMCustomGlobalNodesService,
   nodeContextProcessingService: NodeContextProcessingServiceImpl,
   luigiExtendedGlobalContextConfigService:
-    LuigiExtendedGlobalContextConfigServiceImpl,
+    PMLuigiExtendedGlobalContextService,
   headerBarConfigService: HeaderBarConfigServiceImpl,
   userProfileConfigService: UserProfileConfigServiceImpl,
   routingConfigService: CustomRoutingConfigServiceImpl,


### PR DESCRIPTION
Adds a backend `GET /api/ias-token` endpoint that reads the `openmfp_auth_cookie` session cookie, exchanges it for a Keycloak access token via token refresh, then calls the Keycloak broker to retrieve a SAP IAS token. `cookie-parser` middleware is applied in `main.ts` so `req.cookies` is populated.

On the frontend, replaces `LuigiExtendedGlobalContextConfigServiceImpl` with a new `PMLuigiExtendedGlobalContextService` that fetches the IAS token and merges it into the Luigi global context, making it available to microfrontends that call SAP IAS-protected APIs such as the D1 API.

- `backend/src/ias-token.controller.ts` — new controller with token exchange logic
- `backend/src/main.ts` — applies `cookieParser()` middleware
- `backend/src/app.module.ts` — registers `IasTokenController` on `AppModule`
- `frontend/src/app/services/pm-luigi-extended-global-context.service.ts` — new service wrapping the base implementation and adding `iasToken`
- `frontend/src/main.ts` — wires `PMLuigiExtendedGlobalContextService` as the `luigiExtendedGlobalContextConfigService`